### PR TITLE
Fix frame number comparison for >256 frames

### DIFF
--- a/ros2bag2video.py
+++ b/ros2bag2video.py
@@ -314,7 +314,7 @@ class RosVideoWriter(Node):
         kill program once done.
         Otherwise, continue incrementing frame count.
         '''
-        if self.frame_no is self.count:
+        if self.frame_no == self.count:
             p1 = subprocess.Popen([VIDEO_CONVERTER_TO_USE,
                                   '-framerate',
                                    str(self.fps),


### PR DESCRIPTION
As https://stackoverflow.com/a/2239753 states, the `is` operator only works for integers up to 266. So in general, `==` should be used