### PR TITLE
Galactic support.

### DIFF
--- a/ros2bag2video.py
+++ b/ros2bag2video.py
@@ -230,7 +230,7 @@ class RosVideoWriter(Node):
                 msg_fmt = 'bayer_bggr8'
             elif msg_encoding.find('rggb8') != -1:
                 pix_fmt = 'bayer_rggb8'
-                msg_fmt = 'bayer_bggr8'
+                msg_fmt = 'bayer_rggb8'
             elif msg_encoding.find('rgb8') != -1:
                 pix_fmt = 'rgb24'
                 msg_fmt = 'bgr8'

--- a/ros2bag2video.py
+++ b/ros2bag2video.py
@@ -28,7 +28,7 @@ try:
     from theora_image_transport.msg import Packet
 except Exception:
     pass
-from rosbag2_transport import rosbag2_transport_py
+# from rosbag2_transport import rosbag2_transport_py
 from ros2bag.api import check_path_exists
 from ros2cli.node import NODE_NAME_PREFIX
 from argparse import FileType


### PR DESCRIPTION
Hello!

There was one import line "from rosbag2_transport import rosbag2_transport_py". 
Galactic doesn't export rosbag2_transport anymore.

I noticed that it wasn't being used anywhere in the code so I just commented it out and it worked.

Also line 32, 33 imports also don't seem to be used but I did not comment/delete them.

Also bayer_rggb8 seemed to be using bggr8 so I also changed that. The code didn't work otherwise.

Best,
Leo.