### PR TITLE
fix docker run volume mapping and speed up image processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ options:
 ```bash
 docker run -it --rm \
     --name rosbag2video_c \
-    -v ./:/rosbag2video_workspace \
+    -v .:/rosbag2video_workspace \
   rosbag2video:noetic bash
 ```
 
@@ -85,7 +85,7 @@ python3 rosbag2video.py -t <topic_name> -i <bag_file_name> -o <output_video_file
 ```bash
 docker run -it --rm \
     --name rosbag2video_c \
-    -v ./:/rosbag2video_workspace \
+    -v .:/rosbag2video_workspace \
   rosbag2video:humble bash
 ```
 

--- a/rosbag2video.py
+++ b/rosbag2video.py
@@ -394,7 +394,6 @@ if __name__ == "__main__":
 
         bridge = CvBridge()
         save_image_from_rosbag(bridge, reader, conn, msg_type)
-        # for i in range(message_count if args.frames < 0 else min(message_count, args.frames)):
 
     # Construct video from image sequence
     pix_fmt = get_pix_fmt(msg_encoding)


### PR DESCRIPTION
### Purpose of this PR
I was looking for a way to convert a ROS2 bag into a video, and I came across this project.
But I encountered the following issues when I was testing out one of my bags:
- The Docker command does not work, due to invalid volume path mapping.
- The processing speed was progressively getting slower as the frame counter grew, and it took about 1 hour for a 426-frame video.

So I found out the problems and made these changes.

### Changes
- Change docker run volume mapping from ./: to .:
- Image extraction is now at O(n) and not O(n^2)